### PR TITLE
Plugin2 compatibility changes.

### DIFF
--- a/lib/Dancer2/Plugin/RootURIFor.pm
+++ b/lib/Dancer2/Plugin/RootURIFor.pm
@@ -7,12 +7,11 @@ package Dancer2::Plugin::RootURIFor;
 # ABSTRACT: Mountpoint-agnostic uri builder for Dancer2
 
 use URI::Escape;
-use Dancer2 0.15;
-use Dancer2::Plugin;
+use Dancer2::Plugin 0.15;
 
 register root_uri_for => sub {
     my ( $dsl, $part, $params, $dont_escape ) = @_;
-    my $uri = $dsl->request->base;
+    my $uri = $dsl->app->request->base;
 
     $part =~ s{^/*}{/};
     $uri->path("$part");


### PR DESCRIPTION
Changes needed for new Dancer2::Plugin (to be released very soon).
- don't `use Dancer2`
- get request via `$dsl->app->request`

Ref: https://github.com/PerlDancer/Dancer2/issues/1078 and https://github.com/PerlDancer/Dancer2/issues/1010
